### PR TITLE
Edge Artifact Improvement

### DIFF
--- a/fibat.m
+++ b/fibat.m
@@ -19,6 +19,9 @@ while true
         threshVal = testVals(testNum);
         
         imgThresh = applyThresh(img, threshVal);
+        if C.maxSize ~= inf
+            imgThresh = xor(bwareaopen(imgThresh, 0), bwareaopen(imgThresh, C.maxSize));
+        end
         imgThresh = morphologicalOps(imgThresh);
         
         % Apply criteria


### PR DESCRIPTION
Added code to help fibat.m deal with edge artifacts from motion correction that are above the initial threshold.  This if statement helps when selecting the first threshold if motion artifact borders would otherwise close out the whole frame.